### PR TITLE
Add docs on `target` attribute for script tag

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -247,6 +247,8 @@ attributes:
   blocking manner.
 * `worker` - a flag to indicate your Python code is to be run on a web worker
   instead of the "main thread" that looks after the user interface.
+* `target` - The id or selector of the element where calls to
+  [`display()`](#pyscriptdisplay) should write their values. 
 
 !!! tip 
 
@@ -785,6 +787,11 @@ There are some caveats:
 * When used in the main thread, the `display` function automatically uses
   the current `<script>` tag as the `target` into which the content will
   be displayed.
+
+    - If the `<script>` tag has the `target` attribute, the element on the page
+    with that ID (or which matches that selector) will be used to display
+    the content instead.
+
 * When used in a worker, the `display` function needs an explicit
   `target="dom-id"` argument to identify where the content will be
   displayed.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -792,9 +792,6 @@ There are some caveats:
     with that ID (or which matches that selector) will be used to display
     the content instead.
 
-* When used in a worker, the `display` function needs an explicit
-  `target="dom-id"` argument to identify where the content will be
-  displayed.
 * In both the main thread a worker, `append=False` is the default
   behaviour.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -787,11 +787,9 @@ There are some caveats:
 * When used in the main thread, the `display` function automatically uses
   the current `<script>` tag as the `target` into which the content will
   be displayed.
-
     - If the `<script>` tag has the `target` attribute, the element on the page
     with that ID (or which matches that selector) will be used to display
     the content instead.
-
 * In both the main thread a worker, `append=False` is the default
   behaviour.
 


### PR DESCRIPTION
if pyscript/pyscript#1751 lands (fixing the behavior of the `target` attributes on script tags), this adds documentation to match.