### PR TITLE
Correct custom JS

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,8 @@
 site_name: PyScript
 
+extra_javascript:
+    - javascripts/mini-coi.js
+
 theme:
     name: material
 

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,6 +1,11 @@
 {% extends "base.html" %}
 
 {% block libs %}
-<script src="./javascripts/mini-coi.js"></script>
+{%- for script in config.extra_javascript %}
+  {{ script | script_tag }}
+{%- endfor %}
 {{ super() }}
+{% endblock %}
+
+{% block scripts %}
 {% endblock %}


### PR DESCRIPTION
Ensure extra JS files are properly handled and referenced in the `<head>` of all documents, rather than below the footer.