### PR TITLE
Move `mini-coi.js` to root

### DIFF
--- a/docs/mini-coi.js
+++ b/docs/mini-coi.js
@@ -1,0 +1,28 @@
+/*! coi-serviceworker v0.1.7 - Guido Zuidhof and contributors, licensed under MIT */
+/*! mini-coi - Andrea Giammarchi and contributors, licensed under MIT */
+(({ document: d, navigator: { serviceWorker: s } }) => {
+  if (d) {
+    const { currentScript: c } = d;
+    s.register(c.src, { scope: c.getAttribute('scope') || '.' }).then(r => {
+      r.addEventListener('updatefound', () => location.reload());
+      if (r.active && !s.controller) location.reload();
+    });
+  }
+  else {
+    addEventListener('install', () => skipWaiting());
+    addEventListener('activate', e => e.waitUntil(clients.claim()));
+    addEventListener('fetch', e => {
+      const { request: r } = e;
+      if (r.cache === 'only-if-cached' && r.mode !== 'same-origin') return;
+      e.respondWith(fetch(r).then(r => {
+        const { body, status, statusText } = r;
+        if (!status || status > 399) return r;
+        const h = new Headers(r.headers);
+        h.set('Cross-Origin-Opener-Policy', 'same-origin');
+        h.set('Cross-Origin-Embedder-Policy', 'require-corp');
+        h.set('Cross-Origin-Resource-Policy', 'cross-origin');
+        return new Response(body, { status, statusText, headers: h });
+      }));
+    });
+  }
+})(self);

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: PyScript
 
 extra_javascript:
-    - javascripts/mini-coi.js
+    - mini-coi.js
 
 theme:
     name: material


### PR DESCRIPTION
Moves `mini-coi.js` out of the javascripts folder into the root of the project, to resolve an error message complaining about the scope of the Service Worker.

Fixes #42. As I mentioned over there, in local testing the embedded examples _work fine as-is_ and break when the error message is resolved, so a difficult thing to test locally... but given that the embedded examples on `docs.pyscript.net` appear to currently be broken, I don't think this PR can make things worse? 😅