### PR TITLE
Automatically update imports in `.md` files

### DIFF
--- a/version-update.js
+++ b/version-update.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+
+const { join } = require('path');
+const { readdirSync, readFileSync, statSync, writeFileSync } = require('fs');
+
+const { version } = require(join(__dirname, 'version.json'));
+const calVer = /\/\d{4}\.\d{1,2}\.\d{1,2}\//g;
+
+const patch = directory => {
+  for (const file of readdirSync(directory)) {
+    const path = join(directory, file);
+    if (file.endsWith('.md')) {
+      writeFileSync(
+        path,
+        readFileSync(path).toString().replace(
+          calVer,
+          `/${version}/`
+        )
+      );
+    }
+    else if (statSync(path).isDirectory())
+      patch(path);
+  }
+};
+
+patch(join(__dirname, 'docs'));


### PR DESCRIPTION
This MR simply crawls the docs to change the version accordingly with the one specified in `version.json` file.

The logic is that once that file version is changed, any example using `/YYYY.M.V/` to import the module gets updated to reflect the current latest version.