### PR TITLE
Small text change for distinction between pyscript.net and pyscript.com

### DIFF
--- a/docs/beginning-pyscript.md
+++ b/docs/beginning-pyscript.md
@@ -38,7 +38,7 @@ All PyScript applications need three things:
    how your application works.
 
 Create these files with your favourite code editor on your local file system.
-Alternatively, [pyscript.com](https://pyscript.com) is a cloud-hosted service 
+Alternatively, [pyscript.com](https://pyscript.com) is a free cloud-hosted service 
 by Anaconda that streamlines organising, previewing and deploying your application.
 The distinction between [pyscript.net](https://pyscript.net) and 
 [pyscript.com](https://pyscript.com) on the FAQ on [pyscript.com](https://pyscript.com).

--- a/docs/beginning-pyscript.md
+++ b/docs/beginning-pyscript.md
@@ -38,8 +38,10 @@ All PyScript applications need three things:
    how your application works.
 
 Create these files with your favourite code editor on your local file system.
-Alternatively, [pyscript.com](https://pyscript.com) will take away all the pain
-of organising, previewing and deploying your application.
+Alternatively, [pyscript.com](https://pyscript.com) is a cloud-hosted service 
+by Anaconda that streamlines organising, previewing and deploying your application.
+The distinction between [pyscript.net](https://pyscript.net) and 
+[pyscript.com](https://pyscript.com) on the FAQ on [pyscript.com](https://pyscript.com).
 
 If you're using your local file system, you'll need a way to view your
 application in your browser. If you already have Python installed on

--- a/docs/beginning-pyscript.md
+++ b/docs/beginning-pyscript.md
@@ -41,7 +41,7 @@ Create these files with your favourite code editor on your local file system.
 Alternatively, [pyscript.com](https://pyscript.com) is a free cloud-hosted service 
 by Anaconda that streamlines organising, previewing and deploying your application.
 For more information about the distinction between [pyscript.net](https://pyscript.net) and       
-[pyscript.com](https://pyscript.com) on the FAQ on [pyscript.com](https://pyscript.com).
+[pyscript.com](https://pyscript.com), check out the FAQ on [pyscript.com](https://pyscript.com).
 
 If you're using your local file system, you'll need a way to view your
 application in your browser. If you already have Python installed on

--- a/docs/beginning-pyscript.md
+++ b/docs/beginning-pyscript.md
@@ -40,7 +40,7 @@ All PyScript applications need three things:
 Create these files with your favourite code editor on your local file system.
 Alternatively, [pyscript.com](https://pyscript.com) is a free cloud-hosted service 
 by Anaconda that streamlines organising, previewing and deploying your application.
-The distinction between [pyscript.net](https://pyscript.net) and 
+For more information about the distinction between [pyscript.net](https://pyscript.net) and       
 [pyscript.com](https://pyscript.com) on the FAQ on [pyscript.com](https://pyscript.com).
 
 If you're using your local file system, you'll need a way to view your


### PR DESCRIPTION
As somebody without pyscript experience, adding a small distinction between pyscript.net and pyscript.com in the docs.