### PR TITLE
beginning-pyscript.md (correct .json documentation)

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/docs/beginning-pyscript.md
+++ b/docs/beginning-pyscript.md
@@ -80,7 +80,9 @@ You can see this application embedded into the page below (try it out!):
 Let's explore each of the three files that make this app work.
 
 ### pyscript.json
-
+[pyscript.com](https://pyscript.com) does not create a pyscript.json file automatically, 
+click the (`New File`) button and create a new file named (`pyscript.json`). [pyscript.com](https://pyscript.com) defaults to creating a (`pyscript.toml`)
+file, which is not to be used in this tutorial; the configuration will need to be changed later.
 This file tells PyScript and your browser about various
 [configurable aspects](../user-guide/configuration)
 of your application. Put simply, it tells PyScript what it needs in order to run
@@ -151,8 +153,8 @@ attributes are [built into PyScript](user-guide/builtins.md#html-attributes).
 
 We put all this together in the `script` tag at the end of the `<body>`. This
 tells the browser we're using PyScript (`type="py"`), and where PyScript
-should find the Python source code (`src="./main.py"`). Finally, we indicate
-where PyScript should find the configuration (`config="./pyscript.json"`).
+should find the Python source code (`src="./main.py"`). The default configuration is (`config="./pyscript.toml"`); but since creating the (`pyscript.json`) file, it's imperative that the final step is indicating
+where PyScript should find the configuration which should correctly be (`config="./pyscript.json"`).
 
 In the end, our HTML should look like this:
 


### PR DESCRIPTION
Prior to my changes, the documentation/steps did not reference that the user should create a .json fail, and ensure the configuration is correctly pointing to pyscript.json. I'd also like to note that at line 68 "![PyScript.com](assets/images/pyscript.com.png) " is obsolete as it does not depict a pyscript.json file being on the page, only a pyscript.toml file which is not used but automatically created by the website. 