### PR TITLE
Add m/py:progress events description

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -766,6 +766,52 @@ The following code demonstrates a `pyscript.WebSocket` in action.
     ws = WebSocket(url="ws://example.com/socket", onmessage=onmessage)
     ```
 
+### `pyscript.js_import`
+
+If a JavaScript module is only needed under certain circumstances, we provide
+an asynchronous way to import packages that were not originally referenced in
+your configuration.
+
+```html title="A pyscript.js_import example."
+<script type="py">
+from pyscript import js_import, window
+
+escaper, = await js_import("https://esm.run/html-escaper")
+
+window.console.log(escaper)
+```
+
+The `js_import` call returns an asynchronous tuple containing the JavaScript
+modules referenced as string arguments.
+
+### `pyscript.py_import`
+
+!!! warning
+
+    **This is an experimental feature.**
+
+    Feedback and bug reports are welcome!
+
+If you have a lot of Python packages referenced in your configuration, startup
+performance may be degraded as these are downloaded.
+
+If a Python package is only needed under certain circumstances, we provide an
+asynchronous way to import packages that were not originally referenced in your
+configuration.
+
+```html title="A pyscript.py_import example."
+<script type="py">
+from pyscript import py_import
+
+matplotlib, regex, = await py_import("matplotlib", "regex")
+
+print(matplotlib, regex)
+</script>
+```
+
+The `py_import` call returns an asynchronous tuple containing the Python
+modules provided by the packages referenced as string arguments.
+
 ## Main-thread only features
 
 ### `pyscript.PyWorker`
@@ -862,52 +908,6 @@ for el in document.querySelectorAll("[type='py'][worker][name]"):
 ```
 
 ## Worker only features
-
-### `pyscript.js_import`
-
-If a JavaScript module is only needed under certain circumstances, we provide
-an asynchronous way to import packages that were not originally referenced in
-your configuration.
-
-```html title="A pyscript.js_import example."
-<script type="py">
-from pyscript import js_import, window
-
-escaper, = await js_import("https://esm.run/html-escaper")
-
-window.console.log(escaper)
-```
-
-The `js_import` call returns an asynchronous tuple containing the JavaScript
-modules referenced as string arguments.
-
-### `pyscript.py_import`
-
-!!! warning
-
-    **This is an experimental feature.**
-
-    Feedback and bug reports are welcome!
-
-If you have a lot of Python packages referenced in your configuration, startup
-performance may be degraded as these are downloaded.
-
-If a Python package is only needed under certain circumstances, we provide an
-asynchronous way to import packages that were not originally referenced in your
-configuration.
-
-```html title="A pyscript.py_import example."
-<script type="py">
-from pyscript import py_import
-
-matplotlib, regex, = await py_import("matplotlib", "regex")
-
-print(matplotlib, regex)
-</script>
-```
-
-The `py_import` call returns an asynchronous tuple containing the Python
-modules provided by the packages referenced as string arguments.
 
 ### `pyscript.sync`
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -682,6 +682,22 @@ done"` message is written to the browser's console.
 </script>
 ```
 
+#### m/py:progress
+
+The `py:progress` or `mpy:progress` event triggers on the main thread *during* interpreter bootstrap, being this either on *main* or *worker*.
+
+Following previous work around progress events from *micropip*, the received `event.detail` will be a string that confine operations between `Loading {what}` and `Loaded {what}`, where the first event would hence be `Loading Pyodide` and the last one per each bootstrap would be `Loaded Pyodide`.
+
+In between all operations will be forwarded as `event.detail`, such as:
+
+  * `Loading files` and `Loaded files`, when `[files]` is found in the optional config
+  * `Loading fetch` and `Loaded fetch`, when `[fetch]` is found in the optional config
+  * `Loading JS modules` and `Loaded JS modules`, when `[js_modules.main]` or `[js_modules.worker]`
+is found in the optional config
+  * finally, all optional packages handled via *micropip* or *mip* will also trigger various `Loading ...` and `Loaded ...` events so that users can actually see what is going on while the *app* is bootstrapping
+
+An example of this listener applied to a dialog cna be found in here: https://agiammarchi.pyscriptapps.com/kmeans-in-panel-copy/v1/
+
 ### Packaging pointers
 
 Applications need third party packages and [PyScript can be configured to

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -684,19 +684,28 @@ done"` message is written to the browser's console.
 
 #### m/py:progress
 
-The `py:progress` or `mpy:progress` event triggers on the main thread *during* interpreter bootstrap, being this either on *main* or *worker*.
+The `py:progress` or `mpy:progress` event triggers on the main thread *during*
+interpreter bootstrap (no matter if your code is running on main or in a
+worker).
 
-Following previous work around progress events from *micropip*, the received `event.detail` will be a string that confine operations between `Loading {what}` and `Loaded {what}`, where the first event would hence be `Loading Pyodide` and the last one per each bootstrap would be `Loaded Pyodide`.
+The received `event.detail` is a string that indicates operations between
+`Loading {what}` and `Loaded {what}`. So, the first event would be, for
+example, `Loading Pyodide` and the last one per each bootstrap would be
+`Loaded Pyodide`.
 
-In between all operations will be forwarded as `event.detail`, such as:
+In between all operations are `event.detail`s, such as:
 
-  * `Loading files` and `Loaded files`, when `[files]` is found in the optional config
-  * `Loading fetch` and `Loaded fetch`, when `[fetch]` is found in the optional config
-  * `Loading JS modules` and `Loaded JS modules`, when `[js_modules.main]` or `[js_modules.worker]`
-is found in the optional config
-  * finally, all optional packages handled via *micropip* or *mip* will also trigger various `Loading ...` and `Loaded ...` events so that users can actually see what is going on while the *app* is bootstrapping
+  * `Loading files` and `Loaded files`, when `[files]` is found in the optional
+    config
+  * `Loading fetch` and `Loaded fetch`, when `[fetch]` is found in the optional
+     config
+  * `Loading JS modules` and `Loaded JS modules`, when `[js_modules.main]` or
+    `[js_modules.worker]` is found in the optional config
+  * finally, all optional packages handled via *micropip* or *mip* will also
+    trigger various `Loading ...` and `Loaded ...` events so that users can see
+    what is going on while PyScript is bootstrapping
 
-An example of this listener applied to a dialog cna be found in here: https://agiammarchi.pyscriptapps.com/kmeans-in-panel-copy/v1/
+An example of this listener applied to a dialog can be [found in here](https://agiammarchi.pyscriptapps.com/kmeans-in-panel-copy/v1/).
 
 ### Packaging pointers
 

--- a/docs/user-guide/offline.md
+++ b/docs/user-guide/offline.md
@@ -40,7 +40,7 @@ cd pyscript-offline
 Build PyScript core by cloning the project repository and follow the
 instructions in our [developer guide](../developers.md)
 
-Once completed, copy the `build` folder, that was been created by the build
+Once completed, copy the `dist` folder, that has been created by the build
 step, into your `pyscript-offline` folder.
 
 ### PyScript core from `npm`
@@ -114,7 +114,7 @@ python3 -m http.server -d ./public/
 If you would like to test `worker` features, try instead:
 
 ```sh
-npx static-handler --coi ./public/
+npx mini-coi ./public/
 ```
 
 ## Download a local interpreter
@@ -231,7 +231,7 @@ Finally, we need the ability to install Python packages from a local source
 when using Pyodide.
 
 Put simply, we use the packages bundle from
-[pyodide releases](https://github.com/pyodide/pyodide/releases/tag/0.24.1).
+[pyodide releases](https://github.com/pyodide/pyodide/releases/tag/0.26.2).
 
 !!! warning
 
@@ -240,8 +240,8 @@ Put simply, we use the packages bundle from
     It contains each package that is required by Pyodide, and Pyodide will only
     load packages when needed.
 
-Once downloaded and extracted (we're using version `0.24.1` in this example),
-we can simply copy the files and folders inside the `pyodide-0.24.1/pyodide/*`
+Once downloaded and extracted (we're using version `0.26.2` in this example),
+we can simply copy the files and folders inside the `pyodide-0.26.2/pyodide/*`
 directory into our `./public/pyodide/*` folder.
 
 Feel free to either skip or replace the content, or even directly move the


### PR DESCRIPTION
This MR describes latest `mpy:progress` and `py:progress` events and it takes the opportunity to also fix a misplacement around `js_import` and `py_import`.