### PR TITLE
Add outdated version warning

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,7 @@ site_name: PyScript
 
 theme:
     name: material
+    custom_dir: overrides
 
     logo: assets/images/pyscript-black.svg
 

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block outdated %}
+  You're not viewing the latest version.
+  <a href="{{ config.site_url or '../' }}"> 
+    <strong>Click here to go to latest.</strong>
+  </a>
+{% endblock %} 


### PR DESCRIPTION
As suggested by @kattni (ty!) during a community call, it is currently easy for users to find a version of our docs that aren't the latest version. This PR adds an outdated mkdocs extension to show a warning with a link to view the latest version. I was trying to go for clear but slightly playful on the message - open to different wording as well.

<img width="435" alt="Screenshot 2025-07-01 at 5 32 50 PM" src="https://github.com/user-attachments/assets/0cd5fad8-50c8-4981-8244-b0a752b3d708" />


I tested this locally with:

```
mike deploy 2025.7.1 latest
mike deploy 2024.12.1 old
mike set-default latest
mike serve
```